### PR TITLE
feat: implement LinkButtonComponent backend

### DIFF
--- a/src/main/java/tech/catheu/jeamlit/components/input/LinkButtonComponent.java
+++ b/src/main/java/tech/catheu/jeamlit/components/input/LinkButtonComponent.java
@@ -1,0 +1,163 @@
+package tech.catheu.jeamlit.components.input;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import jakarta.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+import tech.catheu.jeamlit.core.JtContainer;
+import tech.catheu.jeamlit.core.JtComponent;
+import tech.catheu.jeamlit.core.JtComponentBuilder;
+
+import java.io.StringWriter;
+
+import static tech.catheu.jeamlit.core.utils.Preconditions.checkArgument;
+
+public class LinkButtonComponent extends JtComponent<JtComponent.NONE> {
+    // the following fields are protected to be visible to the template engine - see render function
+    protected final String label;
+    protected final String url;
+    protected final String type;
+    protected final String icon;
+    protected final String help;
+    protected final boolean disabled;
+    protected final boolean useContainerWidth; // deprecated but still supported
+    protected final String width;
+
+    private static final Mustache registerTemplate;
+    private static final Mustache renderTemplate;
+
+    static {
+        final MustacheFactory mf = new DefaultMustacheFactory();
+        registerTemplate = mf.compile("components/input/LinkButtonComponent.register.html.mustache");
+        renderTemplate = mf.compile("components/input/LinkButtonComponent.render.html.mustache");
+    }
+    
+    private LinkButtonComponent(final Builder builder) {
+        super(builder.generateKeyForInteractive(), JtComponent.NONE.NONE, null);
+
+        this.label = builder.label;
+        this.url = builder.url;
+        this.type = builder.type;
+        this.icon = builder.icon;
+        this.help = builder.help;
+        this.disabled = builder.disabled;
+        this.useContainerWidth = builder.useContainerWidth;
+        this.width = builder.width;
+    }
+    
+    public static class Builder extends JtComponentBuilder<JtComponent.NONE, LinkButtonComponent, Builder> {
+        private final String label;
+        private final String url;
+        private String type = "secondary";
+        private String icon;
+        private String help;
+        private boolean disabled = false;
+        private boolean useContainerWidth = false; // deprecated
+        private String width = "content";
+        
+        public Builder(final @Nonnull String label, final @Nonnull String url) {
+            // Validate required parameters
+            if (label == null || label.trim().isEmpty()) {
+                throw new IllegalArgumentException("Link button label cannot be null or empty");
+            }
+            if (url == null || url.trim().isEmpty()) {
+                throw new IllegalArgumentException("Link button URL cannot be null or empty");
+            }
+            this.label = label;
+            this.url = url;
+        }
+        
+        public Builder type(final @Nonnull String type) {
+            if (!type.equals("primary") && !type.equals("secondary") && !type.equals("tertiary")) {
+                throw new IllegalArgumentException("Link button type must be 'primary', 'secondary', or 'tertiary'. Got: " + type);
+            }
+            this.type = type;
+            return this;
+        }
+        
+        public Builder icon(final String icon) {
+            this.icon = icon;
+            return this;
+        }
+        
+        public Builder help(final String help) {
+            this.help = help;
+            return this;
+        }
+        
+        public Builder disabled(final boolean disabled) {
+            this.disabled = disabled;
+            return this;
+        }
+        
+        public Builder useContainerWidth(final boolean useContainerWidth) {
+            // Deprecated parameter - for backward compatibility, maps to width
+            this.useContainerWidth = useContainerWidth;
+            if (useContainerWidth) {
+                this.width = "stretch";
+            }
+            return this;
+        }
+
+        public Builder width(final String width) {
+            if (width != null && !width.equals("content") && !width.equals("stretch")) {
+                // Try to parse as integer for pixel width
+                try {
+                    Integer.parseInt(width);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Width must be 'content', 'stretch', or a valid integer for pixel width. Got: " + width);
+                }
+            }
+            this.width = width != null ? width : "content";
+            return this;
+        }
+
+        public Builder width(final int widthPixels) {
+            if (widthPixels <= 0) {
+                throw new IllegalArgumentException("Width in pixels must be positive. Got: " + widthPixels);
+            }
+            this.width = String.valueOf(widthPixels);
+            return this;
+        }
+        
+        @Override
+        public LinkButtonComponent build() {
+            return new LinkButtonComponent(this);
+        }
+    }
+    
+    @Override
+    protected String register() {
+        final StringWriter writer = new StringWriter();
+        registerTemplate.execute(writer, this);
+        return writer.toString();
+    }
+    
+    @Override
+    protected String render() {
+        final StringWriter writer = new StringWriter();
+        renderTemplate.execute(writer, this);
+        return writer.toString();
+    }
+    
+    @Override
+    protected TypeReference<JtComponent.NONE> getTypeReference() {
+        return new TypeReference<>() {};
+    }
+
+    @Override
+    protected void resetIfNeeded() {
+        // Link button doesn't need reset behavior
+    }
+
+    @Override
+    public void beforeUse(@NotNull JtContainer container) {
+        final String parentFormComponentKey = container.getParentFormComponentKey();
+        checkArgument(parentFormComponentKey == null,
+                      "Attempting to create a link button inside a form. %s. A link button cannot be added to a form. Please use a form submit button instead with Jt.formSubmitButton.",
+                      parentFormComponentKey,
+                      parentFormComponentKey);
+    }
+}

--- a/src/main/resources/components/input/LinkButtonComponent.register.html.mustache
+++ b/src/main/resources/components/input/LinkButtonComponent.register.html.mustache
@@ -1,0 +1,331 @@
+<script type="module">
+    import {LitElement, html, css} from "{{ LIT_DEPENDENCY }}";
+
+    class JtLinkButton extends LitElement {
+        static styles = css`
+            :host {
+                display: block;
+                margin: var(--jt-spacing-md) 0;
+            }
+
+            .button-container {
+                display: flex;
+                align-items: center;
+                gap: var(--jt-spacing-sm);
+            }
+
+            .button {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                gap: var(--jt-spacing-sm);
+
+                padding: var(--jt-spacing-sm) var(--jt-spacing-lg);
+                border: 1px solid transparent;
+                border-radius: var(--jt-border-radius);
+
+                font-family: var(--jt-font-family);
+                font-size: var(--jt-font-size-base);
+                font-weight: var(--jt-font-weight-medium);
+                line-height: var(--jt-line-height-tight);
+                text-decoration: none;
+                white-space: nowrap;
+
+                cursor: pointer;
+                transition: all var(--jt-transition-fast);
+
+                position: relative;
+                overflow: hidden;
+            }
+
+            :host([use-container-width]) .button {
+                width: 100%;
+            }
+
+            :host([width="stretch"]) .button {
+                width: 100%;
+            }
+
+            :host([width="content"]) .button {
+                width: auto;
+            }
+
+            .button:focus {
+                outline: 2px solid var(--jt-primary-color);
+                outline-offset: 2px;
+            }
+
+            .button:disabled {
+                opacity: 0.5;
+                cursor: not-allowed;
+                pointer-events: none;
+            }
+
+            /* Button Types */
+
+            .button.primary {
+                background-color: var(--jt-theme-color);
+                color: var(--jt-text-white);
+                border-color: var(--jt-theme-color);
+            }
+
+            .button.primary:hover:not(:disabled) {
+                background-color: var(--jt-theme-hover);
+                border-color: var(--jt-theme-hover);
+                transform: translateY(-1px);
+                box-shadow: var(--jt-shadow);
+            }
+
+            .button.primary:active:not(:disabled) {
+                background-color: var(--jt-theme-active);
+                border-color: var(--jt-theme-active);
+                transform: translateY(0);
+                box-shadow: var(--jt-shadow-sm);
+            }
+
+            .button.secondary {
+                background-color: var(--jt-bg-primary);
+                color: var(--jt-text-primary);
+                border-color: var(--jt-border-color);
+            }
+
+            .button.secondary:hover:not(:disabled) {
+                background-color: var(--jt-bg-primary);
+                border-color: var(--jt-theme-color);
+                color: var(--jt-theme-color);
+                transform: translateY(-1px);
+                box-shadow: var(--jt-shadow);
+            }
+
+            .button.secondary:active:not(:disabled) {
+                background-color: var(--jt-bg-secondary);
+                border-color: var(--jt-theme-active);
+                color: var(--jt-theme-active);
+                transform: translateY(0);
+                box-shadow: var(--jt-shadow-sm);
+            }
+
+            .button.tertiary {
+                background-color: transparent;
+                color: var(--jt-text-secondary);
+                border-color: transparent;
+            }
+
+            .button.tertiary:hover:not(:disabled) {
+                background-color: transparent;
+                color: var(--jt-theme-color);
+                border-color: transparent;
+            }
+
+            .button.tertiary:active:not(:disabled) {
+                background-color: var(--jt-bg-secondary);
+                color: var(--jt-theme-active);
+            }
+
+            /* Icon styling */
+
+            .icon {
+                font-size: var(--jt-font-size-lg);
+                font-family: 'Material Symbols Rounded';
+                font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            }
+
+            .emoji-icon {
+                font-size: var(--jt-font-size-base);
+            }
+
+            /* Ripple effect */
+
+            .button::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 0;
+                height: 0;
+                border-radius: 50%;
+                background: rgba(255, 255, 255, 0.3);
+                transform: translate(-50%, -50%);
+                transition: width 0.3s, height 0.3s;
+            }
+
+            .button:active::after {
+                width: 200px;
+                height: 200px;
+            }
+
+            /* Markdown formatting in button text */
+
+            .button em {
+                font-style: italic;
+            }
+
+            .button strong {
+                font-weight: var(--jt-font-weight-bold);
+            }
+
+            .button code {
+                background-color: rgba(255, 255, 255, 0.2);
+                padding: 0.1em 0.3em;
+                border-radius: var(--jt-border-radius-sm);
+                font-family: var(--jt-font-family-mono);
+                font-size: 0.9em;
+            }
+
+            .button.primary code {
+                background-color: rgba(255, 255, 255, 0.3);
+            }
+
+            .button.secondary code, .button.tertiary code {
+                background-color: rgba(0, 0, 0, 0.1);
+            }
+
+            .button a {
+                color: inherit;
+                text-decoration: underline;
+            }
+
+            .button del {
+                text-decoration: line-through;
+            }
+        `;
+
+        static properties = {
+            label: {type: String},
+            url: {type: String},
+            type: {type: String},
+            icon: {type: String},
+            help: {type: String},
+            disabled: {type: Boolean},
+            useContainerWidth: {type: Boolean, attribute: 'use-container-width'},
+            width: {type: String}
+        };
+
+        constructor() {
+            super();
+            this.type = 'secondary';
+            this.disabled = false;
+            this.useContainerWidth = false;
+            this.width = 'content';
+        }
+
+        updated(changedProperties) {
+            super.updated(changedProperties);
+            
+            // Handle width changes
+            if (changedProperties.has('width')) {
+                this.updateWidth();
+            }
+        }
+
+        updateWidth() {
+            const button = this.shadowRoot?.querySelector('.button');
+            if (!button) return;
+
+            // Remove existing width styles
+            button.style.removeProperty('width');
+            
+            if (this.width === 'stretch') {
+                button.style.width = '100%';
+            } else if (this.width === 'content') {
+                button.style.width = 'auto';
+            } else if (this.width && !isNaN(parseInt(this.width))) {
+                // Pixel width
+                button.style.width = `${this.width}px`;
+            }
+        }
+
+        // TODO CYRIL use proper library for markdown support
+        formatText(label) {
+            if (!label) return '';
+
+            // Enhanced Markdown formatting
+            return label
+                    // Bold
+                    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                    // Italic
+                    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                    // Code
+                    .replace(/`(.*?)`/g, '<code>$1</code>')
+                    // Links
+                    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>')
+                    // Basic color support :color[text]
+                    .replace(/:([a-zA-Z]+)\[(.*?)\]/g, '<span style="color: $1">$2</span>')
+                    // Strikethrough
+                    .replace(/~~(.*?)~~/g, '<del>$1</del>');
+        }
+
+        isEmoji(str) {
+            // Simple emoji detection
+            return str && str.length <= 2 && /\p{Emoji}/u.test(str);
+        }
+
+        handleClick(e) {
+            if (this.disabled) return;
+
+            // Create ripple effect
+            const button = e.currentTarget;
+            const rect = button.getBoundingClientRect();
+            const size = Math.max(rect.width, rect.height);
+            const x = e.clientX - rect.left - size / 2;
+            const y = e.clientY - rect.top - size / 2;
+
+            const ripple = document.createElement('span');
+            ripple.style.cssText = `
+                        position: absolute;
+                        border-radius: 50%;
+                        background: rgba(255, 255, 255, 0.3);
+                        transform: scale(0);
+                        animation: ripple 0.6s linear;
+                        left: ${x}px;
+                        top: ${y}px;
+                        width: ${size}px;
+                        height: ${size}px;
+                    `;
+
+            button.appendChild(ripple);
+            setTimeout(() => ripple.remove(), 600);
+
+            // Navigate to URL in new tab
+            if (this.url) {
+                window.open(this.url, '_blank', 'noopener,noreferrer');
+            }
+        }
+
+        render() {
+            const iconContent = this.icon ? (
+                    this.isEmoji(this.icon) ?
+                            html`<span class="emoji-icon">${this.icon}</span>` :
+                            html`<span class="icon">${this.icon}</span>`
+            ) : null;
+
+            const formattedLabel = this.formatText(this.label || '');
+
+            return html`
+                <style>
+                    @keyframes ripple {
+                        to {
+                            transform: scale(4);
+                            opacity: 0;
+                        }
+                    }
+                </style>
+                <div class="button-container">
+                    <button
+                            class="button ${this.type}"
+                            ?disabled="${this.disabled}"
+                            @click="${this.handleClick}"
+                            type="button">
+                        ${iconContent}
+                        <span .innerHTML="${formattedLabel}"></span>
+                    </button>
+                    ${this.help ? html`
+                        <jt-tooltip text="${this.help}"></jt-tooltip>
+                    ` : ''}
+                </div>
+            `;
+        }
+    }
+
+    customElements.define('jt-link-button', JtLinkButton);
+</script>

--- a/src/main/resources/components/input/LinkButtonComponent.render.html.mustache
+++ b/src/main/resources/components/input/LinkButtonComponent.render.html.mustache
@@ -1,0 +1,17 @@
+<jt-link-button
+label="{{label}}"
+url="{{url}}"
+type="{{type}}"
+{{#icon}}
+icon="{{icon}}"
+{{/icon}}
+{{#help}}
+help="{{help}}"
+{{/help}}
+{{#disabled}}
+disabled
+{{/disabled}}
+{{#useContainerWidth}}
+use-container-width
+{{/useContainerWidth}}
+width="{{width}}"></jt-link-button>


### PR DESCRIPTION
Implements the LinkButtonComponent backend following Streamlit specifications from issue #30.

## Changes
- Add LinkButtonComponent class with builder pattern
- Support all required parameters: label, url, help, type, icon, disabled, width
- Handle URL navigation in new tab with security best practices
- Maintain consistent styling with existing button components
- Add Lit-based web component templates

## Implementation Notes
- Extends JtComponent<JtComponent.NONE> since link buttons don't return values
- Supports both deprecated use_container_width and new width parameter
- Includes comprehensive parameter validation
- Follows existing project conventions and patterns

Fixes #30

Generated with [Claude Code](https://claude.ai/code)